### PR TITLE
Separation of calc and get functions, isolation of getVolts from resi…

### DIFF
--- a/firmware/Steinhart-Thermistor.cpp
+++ b/firmware/Steinhart-Thermistor.cpp
@@ -1,21 +1,46 @@
 #include "Steinhart-Thermistor.h"
 #include "math.h"
 
+// TURN DEBUG ON?
+#define MYDEBUG FALSE
+
 int Thermistor::getAdc(int numsamples) {
-    delay(1);
+    delay(10);
+    // Initialise vars
     int total = 0;
+    int temp = 0;
+    
+    // After looking at all kinds of fancy median libraries etc, a simple average on a small set (3) works well
+    // The real secret is to get your probe returning sensible avals that don't vary much
     for(int i = 0; i < numsamples; i++) {
-        total += analogRead(_pin);
-        delay(1);
+        // Read the pin
+        temp = analogRead(_pin);
+        // Show some debug output if really required
+        if (MYDEBUG) {
+            Serial.print("pin: ");
+            Serial.print(_pin);
+            Serial.print(" temp: ");
+            Serial.println(temp);
+        }
+        // Add to total
+        total += temp;
+        // Wait a while
+        delay(100);
     }
-    _adc = total / numsamples;
-    return _adc;
+    // Calculate average
+    _aval = (double) total / (double) numsamples;
+    // Debug output
+    if (MYDEBUG) {
+        Serial.print("getADC: ");
+        Serial.println(_aval, 4);
+    }
+    return _aval;
 }
 
-Thermistor::Thermistor(int _pin, int _R, int _Rref, double _A1, double _B1, double _C1, double _D1) {
+Thermistor::Thermistor(int _pin, int _RESISTOR, double _A1, double _B1, double _C1, double _D1, float _VREF) {
     this->_pin = _pin;
-    this->_R = _R;
-    this->_Rref = _Rref;
+    this->_RESISTOR = _RESISTOR;
+    this->_VREF = _VREF;
     this->_A1 = _A1;
     this->_B1 = _B1;
     this->_C1 = _C1;
@@ -23,28 +48,56 @@ Thermistor::Thermistor(int _pin, int _R, int _Rref, double _A1, double _B1, doub
     pinMode(_pin, INPUT);
 }
 
-double Thermistor::getResistance(int numsamples) {
-    _resistance = _R * (4095.0 / getAdc(numsamples) - 1);
+double Thermistor::calcResistance(int numsamples) {
+    // From memory the -1 was part of the voltage dividor calc, not a mistake from the 4096 - 1 typical process
+    // Also you divide if its pullup vs pulldown
+    _resistance = _RESISTOR / ((float) _ADC / getAdc(numsamples) - 1.0f); 
+    
+    // Get the current voltage, its nice to know
+    calcVolts();
+    
     return _resistance;
 }
 
-double Thermistor::getVolts(double vin) {
-    _volts = _resistance / _Rref * vin;
+double Thermistor::getResistance() {
+    return _resistance;
+}
+
+double Thermistor::calcVolts() {
+    // Better to calculate observed volts from known relationship between aval, ADC and reference voltage rather than calculated resistance
+    _volts = (_aval / (float) _ADC) * _VREF;
     return _volts;
 }
 
+double Thermistor::getVolts() {
+    return _volts;
+}
+double Thermistor::getAval() {
+    return _aval;
+}
+
 double Thermistor::getTempK() {
-    _temp_k = log(_resistance / _Rref);
-    _temp_k = 1 / (_A1 + _B1 * _temp_k + _C1 * _temp_k * _temp_k + _D1 * _temp_k * _temp_k * _temp_k);
+    // Nice to cache the log R value
+    double R = log(_resistance);
+    // Slightly optimised 4 part Steinhart Hart
+    _temp_k = 1.0f / (_A1 + (_B1 + _C1 * R + _D1 * R * R) * R);
     return _temp_k;
 }
 
 double Thermistor::getTempC() {
-    _temp_c = getTempK() - 273.15;
+    // Standard Kelvin calc
+    _temp_c = getTempK() - 273.15f;
+    // If the probe is not plugged in, it will return negative values
+    if (_temp_c < 0){
+        // Return 0
+        _temp_c = 0;
+    }
     return _temp_c;
 }
 
 double Thermistor::getTempF() {
+    // Standard Fahrenheit calc, it inherits the 0 degrees celsius minimum, ie 32.
     _temp_f = getTempC() * 9 / 5.0 + 32;
+    // Note, if the temp was 32 then its fair to assume it was a 'null' reading
     return _temp_f;
 }

--- a/firmware/Steinhart-Thermistor.h
+++ b/firmware/Steinhart-Thermistor.h
@@ -2,26 +2,30 @@
 
 class Thermistor {
     private:
+        int _ADC = 4095;
         int _pin;
-        int _R;
-        int _Rref;
-        int _adc;
+        int _RESISTOR;
+        int getAdc(int numsamples);        
+        double _aval;        
         double _A1;
         double _B1;
         double _C1;
         double _D1;
-        int getAdc(int numsamples);
-    public:
         double _resistance;
         double _volts;
+        double calcVolts();
+        float _VREF;
+    public:
         double _temp_k;
         double _temp_c;
         double _temp_f;
-        Thermistor(int _pin, int _R = 10000, int _Rref = 10000, double _A1 = 0.003354016, double _B1 = 0.000256985, double _C1 = 0.000002620131, double _D1 = 0.00000006383091);
-        double getResistance(int numsamples = 1);
-        double getVolts(double vin = 3.3);
+        //Maverick ET-72: Thermistor(int _pin, int _RESISTOR = 19870, float _VREF = 3.3200, double _A1 = 2.4723753e-4, double _B1 = 2.3402251e-4, double _C1 = 0, double _D1 = 1.3879768e-7);
+        Thermistor(int _pin, int _RESISTOR = 47500, double _A1 = 5.36924e-4, double _B1 = 1.91396e-4, double _C1 = 0, double _D1 = 6.60399e-8, float _VREF = 3.3200);
+        double calcResistance(int numsamples = 3);
+        double getAval();
+        double getResistance();
         double getTempF();
         double getTempC();
         double getTempK();
+        double getVolts();
 };
-

--- a/firmware/examples/Steinhart-Thermistor.ino
+++ b/firmware/examples/Steinhart-Thermistor.ino
@@ -7,13 +7,17 @@ void setup() {
 }
 
 void loop() {
-	//Always call getResistance() first.
+	//Always call calcResistance() first.
 	//It's the only function that read the ADC value.
 	//Otherwise you could get a different value for each temperature unit.
 	//You can specify a number of samples. Default = 1.
-	Thermistor.getResistance();
+	Thermistor.calcResistance();
+	Serial.print("Thermistor resistance: ");
+	Serial.println(Thermistor.getResistance();
 	Serial.print("Volts: ");
 	Serial.println(Thermistor.getVolts();
+	Serial.print("Analog value at pin: ");
+	Serial.println(Thermistor.getAval();	
 	Serial.print("Kelvin: ");
 	Serial.println(Thermistor.getTempK());
 	Serial.print("Celsius: ");


### PR DESCRIPTION
Thanks for your code, it sure helped. Unfortunately I spent a lot of time debugging my particular thermistor and so I touched up a few of your functions to aid debugging and isolate calculations (ie getVolts) that could be based on an incorrect resistance calculation.
Let me know your thoughts, I thought it'd be neater to see if we could combine changes rather than having two libraries in the Spark library!
